### PR TITLE
missed save-as-draft button

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -46,6 +46,11 @@
           </li>
         </ul>
         <div class="float-right">
+        <% unless params[:action] == 'edit' %>
+          <div class="join-btn  create-post-btn mb-4">
+            <%= form.submit "Save as draft", class: "text-white" %>
+          </div>
+        <% end %>
         <div class="join-btn create-post-btn mb-4">
         <%= form.submit "Publish", class: "text-white" %>
         </div>


### PR DESCRIPTION
In the Previous pull request, I just missed the save-as-draft button in the new post form page while merging conflicts 