### PR TITLE
issue/post select community  automatically

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,13 +7,14 @@ module ApplicationHelper
         end
         ""
       end
-    
-      def is_error(resource, field)
+
+      def style_error_class(resource, field, css)
         if resource.errors.any?
           resource.errors.full_messages_for(field).each do |error_message|
-            return " border-danger"
+            return (css+" border-danger").to_s
           end
         end
+        return css.to_s
       end
 
-  end 
+  end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,16 +1,14 @@
 module ApplicationHelper
     def error_msg(resource, field)
         if resource.errors.any?
-          resource.errors.full_messages_for(field).each do |error_message|
-            return error_message
-          end
+          return resource.errors.full_messages_for(field).first
         end
         ""
       end
 
       def style_error_class(resource, field, css)
         if resource.errors.any?
-          resource.errors.full_messages_for(field).each do |error_message|
+          if resource.errors.full_messages_for(field)
             return (css+" border-danger").to_s
           end
         end

--- a/app/views/communities/_form.html.erb
+++ b/app/views/communities/_form.html.erb
@@ -6,49 +6,49 @@
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :profile_picture %>
-            <%= form.file_field :profile_image, class: "form-control "+is_error(@community,(:profile_image)).to_s %>
-            <p class="text-danger"><%= error_msg(@community, (:profile_image))  %></p>
+            <%= form.file_field :profile_image, class: style_error_class(@community, :profile_image, "form-control ") %>
+            <p class="text-danger"><%= error_msg(@community, (:profile_image)) %></p>
           </div>
         </div>
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :cover_picture %>
-            <%= form.file_field :cover_image, class: "form-control "+is_error(@community,(:cover_image)).to_s %>
+            <%= form.file_field :cover_image, class: style_error_class(@community, :cover_image, "form-control ") %>
             <p class="text-danger"><%= error_msg(@community, (:cover_image))  %></p>
           </div>
         </div>
         <div class="create-post m-3 ">
           <div class="form-group">
             <%= label_tag :name %>
-            <%= form.text_field :name, class: "form-control"+is_error(@community,(:name)).to_s, maxlength: 16, minlength: 3 %>
+            <%= form.text_field :name, class: style_error_class(@community, :name, "form-control"), maxlength: 16, minlength: 3 %>
             <p class="text-danger"><%= error_msg(@community, (:name))  %></p>
           </div>
         </div>
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :url %>
-            <%= form.text_field :url, class: "form-control"+is_error(@community,(:url)).to_s %>
+            <%= form.text_field :url, class: style_error_class(@community, :url, "form-control") %>
             <p class="text-danger"><%= error_msg(@community, :url)  %></p>
           </div>
         </div>
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :summary %>
-            <%= form.text_field :summary, class: "form-control"+is_error(@community,(:summary)).to_s, minlength: 3  %>
+            <%= form.text_field :summary, class: style_error_class(@community, :summary, "form-control"), minlength: 3  %>
             <p class="text-danger"><%= error_msg(@community, :summary)  %></p>
           </div>
         </div>
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :category %>
-            <%= form.select :category, Community::CATEGORIES, prompt: "Select Category" ,class: "form-control "+is_error(@community,(:category)).to_s %>
+            <%= form.select :category, Community::CATEGORIES, prompt: "Select Category" ,class: style_error_class(@community, :category, "form-control") %>
             <p class="text-danger"><%= error_msg(@community, :category)  %></p>
           </div>
         </div>
         <div class="create-post m-3">
           <div class="form-group">
             <%= label_tag :rules %>
-            <%= form.text_area :rules, class: "form-control"+is_error(@community,(:rules)).to_s %>
+            <%= form.text_area :rules, class: style_error_class(@community, :rules, "form-control") %>
             <p class="text-danger"><%= error_msg(@community, :rules)  %></p>
           </div>
         </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,8 @@
       <div class="card rounded mb-3">
       <div class="form-group">
         <%= label_tag :Community %>
-        <%= form.select :community_id, @my_communities.collect {|option| [option.name, option.id]}, prompt: "Select Community", selected: params[:community_id] , class: "form-select" %>
+        <%= form.select :community_id, @my_communities.collect {|option| [option.name, option.id]}, prompt: "Select Community", selected: selected_community(@my_communities.pluck(:id)) , class: "form-select "+is_error(@post,(:community_id)).to_s %>
+        <p class="text-danger"><%= error_msg(@post, :community_id)  %></p>
       </div>
         </div>
       </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
       <div class="card rounded mb-3">
       <div class="form-group">
         <%= label_tag :Community %>
-        <%= form.select :community_id, @my_communities.collect {|option| [option.name, option.id]}, prompt: "Select Community", selected: selected_community(@my_communities.pluck(:id)) , class: "form-select "+is_error(@post,(:community_id)).to_s %>
+        <%= form.select :community_id, @my_communities.collect {|option| [option.name, option.id]}, prompt: "Select Community", selected: selected_community(@my_communities.pluck(:id)) , class: style_error_class(@post, :community_id, "form-control") %>
         <p class="text-danger"><%= error_msg(@post, :community_id)  %></p>
       </div>
         </div>
@@ -17,15 +17,15 @@
         <div class="col-sm-12">
           <div class="create-post m-3">
             <div class="form-group">
-              <%= form.text_field :title, class: "form-control "+is_error(@post,(:title)).to_s, placeholder: :title, maxlength: 20%>
+              <%= form.text_field :title, class: style_error_class(@post, :title, "form-control"), placeholder: :title, maxlength: 20%>
               <p class="text-danger"><%= error_msg(@post, :title)  %></p>
             </div>
           </div>
           <div class="create-post m-3">
             <div class="form-group">
-              <%= form.rich_text_area :body, class: "textarea "+is_error(@post,(:body)).to_s, placeholder: "Text(optional)" %>
+              <%= form.rich_text_area :body, class: style_error_class(@post, :body, "textarea"), placeholder: "Text(optional)" %>
               <p class="text-danger"><%= error_msg(@post, :body)  %></p>
-              <%= form.file_field :images, multiple: true, :class=>"form-control "+is_error(@post,(:images)).to_s, :placeholder=>"" %>
+              <%= form.file_field :images, multiple: true, class: style_error_class(@post, :images, "form-control"), :placeholder=>"" %>
               <p class="text-danger"><%= error_msg(@post, :images)  %></p>
             </div>
           </div>


### PR DESCRIPTION
When we click create post from home page, the select community column should be a drop down box. When we click create post while we are in a community page, the community should be selected by default as the current community page. It is appearing vice-versa. #127 Resloved