### PR TITLE
Profile page extra space is removed

### DIFF
--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -19,9 +19,9 @@ class PublicController < ApplicationController
     @posts = @profile.posts
     @my_comments = Comment.where(account_id: @profile.id)
     @my_posts = Post.where(account_id: @profile.id)
-    @hot_myposts = Post.where(account_id: @profile.id).order(view_count: :desc).page(params[:page]).per 5
-    @top_myposts = Post.where(account_id: @profile.id).order(view_count: :desc).page(params[:page]).per 5
-    @new_myposts = Post.where(account_id: @profile.id).order(created_at: :desc).page(params[:page]).per 5
+    @hot_myposts = Post.where(account_id: @profile.id).order(view_count: :desc)
+    @top_myposts = Post.where(account_id: @profile.id).order(view_count: :desc)
+    @new_myposts = Post.where(account_id: @profile.id).order(created_at: :desc)
   end
 
 

--- a/app/views/public/profile.html.erb
+++ b/app/views/public/profile.html.erb
@@ -4,24 +4,15 @@
     <div class="tab-content col-sm-8">
       <div id="POSTS" class="tab-pane fade-in active">
         <%= render partial: "public/tab_my_post"%>
-        <div class="tab-content">
-          <div id="hot_myposts" class="tab-pane fade-in infinity active">
+        <div class="tab-content infinity">
+          <div id="hot_myposts" class="tab-pane fade-in active">
             <%= render partial: "posts/list", locals: { posts: @hot_myposts } %>
-            <div class = "infinite-scrolling">
-              <%= link_to_next_page(@hot_myposts, "posts" , :remote => true, class: "text-dark") %>
-            </div>
           </div>
-          <div id="new_myposts" class="tab-pane fade infinity">
+          <div id="new_myposts" class="tab-pane fade">
             <%= render partial: "posts/list", locals: { posts: @new_myposts } %>
-            <div class = "infinite-scrolling">
-              <%= link_to_next_page(@new_myposts, "posts" , :remote => true, class: "text-dark") %>
-            </div>
           </div>
-          <div id="top_myposts" class="tab-pane fade infinity">
+          <div id="top_myposts" class="tab-pane fade">
             <%= render partial: "posts/list", locals: { posts: @top_myposts } %>
-            <div class = "infinite-scrolling">
-              <%= link_to_next_page(@top_myposts, "posts" , :remote => true, class: "text-dark") %>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Due to infinite scrolling the same tabs are render again so same posts is again and again displayed, in addition to that the extra white space also displayed, it is resolved.