### PR TITLE
Admin community name is stored instead of id

### DIFF
--- a/app/admin/communities.rb
+++ b/app/admin/communities.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register Community do
       f.input :summary
       f.input :rules
       f.input :post_count_this_week
-      f.input :category,  :label => 'category', :as => :select, :collection => Category.all.collect {|option| [option.name, option.id]}, :selected => params[:category] 
+      f.input :category,  :label => 'category', :as => :select, :collection => Category.all.collect {|option| [option.name]}, :selected => params[:category] 
       f.input :created_at
       f.input :updated_at
       f.submit "Submit", disable_with: 'Submiting...'


### PR DESCRIPTION
In admin side the id of category is stored in form, so in show page instead of category name, category id is stored, so it is changed to category name.