### PR TITLE
Community owner detail added to admin side table

### DIFF
--- a/app/admin/communities.rb
+++ b/app/admin/communities.rb
@@ -2,7 +2,9 @@ ActiveAdmin.register Community do
   permit_params :account_id, :name, :url, :summary, :rules, :total_members, :category
 
   index do
-    column :account_id
+    column "Owner" do |community|
+      community.account.username
+    end
     column :name
     column :url
     column :summary

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -10,6 +10,7 @@ class Community < ApplicationRecord
   has_one_attached :profile_image
   has_one_attached :cover_image
   has_many :banned_users
+  belongs_to :account
 
   validates_presence_of :summary, :name, :rules, :category
   validates :name, uniqueness: true


### PR DESCRIPTION
Instead of owner name, the account id is visible, now it is changed to owner name. 
Association "belongs_to" is added to account via community
In form field account field is added