### PR TITLE
draft publish toastr message updated

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -49,7 +49,7 @@ def update
       flash[:notice] = t("draft.success")
       redirect_back(fallback_location: edit_community_post_path)
     else
-      flash[:notice] = t("post.updated")
+      flash[:notice] = t("post.success")
       redirect_to community_post_path(@post.community_id)
     end
   else


### PR DESCRIPTION
 When the user publishes a draft post, the success message shows 'post edited successfully'. The success message should be 'post published successfully'. #162 issue resolved