### PR TITLE
admin side-offensive post report reason and category is added

### DIFF
--- a/app/admin/reports.rb
+++ b/app/admin/reports.rb
@@ -4,14 +4,12 @@ ActiveAdmin.register Report do
   index do 
     column :id
     column :post
-    column :category do 
-      report_category = ReportCategory.find_by(params[:report_category_id])
-      report_category.name
+    column "Report Category" do |report|
+      report.report_category.name
     end
-    column :reason do
-      report_reason = ReportReason.find_by(params[:report_reason_id])
-      report_reason.reason
-    end 
+    column "Report Reason" do |report|
+      report.report_reason.reason 
+    end
     column :account
     actions 
   end 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,5 +1,6 @@
 class Report < ApplicationRecord
   belongs_to :post
   belongs_to :report_reason
+  belongs_to :report_category
   belongs_to :account
 end


### PR DESCRIPTION
In admin side - the offensive report for post, the reason and category is wrongly visible, it sis raised as issue, now it is fixed
Now the correct report category and reason is correctly visible.

