### PR TITLE
New community page - account filed is added

### DIFF
--- a/app/admin/communities.rb
+++ b/app/admin/communities.rb
@@ -18,6 +18,7 @@ ActiveAdmin.register Community do
   end 
   form do |f|
     f.inputs "Create Community" do
+      f.input :account
       f.input :name
       f.input :url
       f.input :summary


### PR DESCRIPTION
In creating the community page, I have already added the account id but somehow it is removed, now the error Is fixed again in creating a new community page. The account id is added and the edit form is resolved so that the category is automatically selected when clicking edit from a particular community.