### PR TITLE
Fix/community db

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -30,7 +30,7 @@ class CommunitiesController < ApplicationController
   end
 
   def edit
-    if @community.owner_id == current_account.id
+    if @community.account_id == current_account.id
       render :new
     else
       flash[:alert] = t('form.forbidden')
@@ -41,7 +41,6 @@ class CommunitiesController < ApplicationController
   def create
     @community = Community.new community_values
     @community.account_id = current_account.id
-    @community.owner_id = current_account.id
     if @community.save
       Subscription.create!(community_id: @community.id, account_id: current_account.id)
       flash[:notice] = t('community.success')
@@ -69,7 +68,7 @@ class CommunitiesController < ApplicationController
   end
 
   def mod
-    redirect_back(fallback_location: root_path) and return unless @community.owner_id == current_account.id
+    redirect_back(fallback_location: root_path) and return unless @community.account_id == current_account.id
 
     @banned_user = BannedUser.where(community_id: @community.id)
                              .order(created_at: :desc)

--- a/app/views/communities/show.html.erb
+++ b/app/views/communities/show.html.erb
@@ -58,7 +58,7 @@
     <div class="col-sm-4">
       <div class="card p-2 bg-gradient">
         <p class="h6 pt-2 text-light">About this community</p>
-        <% if @community.owner_id == current_account.id %>
+        <% if @community.account_id == current_account.id %>
           <%= link_to "Mod-Tools", mod_path, class: "btn btn-primary"%>
         <% end %>
       </div>

--- a/db/migrate/20230117163549_remove_owner_id_from_community.rb
+++ b/db/migrate/20230117163549_remove_owner_id_from_community.rb
@@ -1,0 +1,5 @@
+class RemoveOwnerIdFromCommunity < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :communities, :owner_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_03_072531) do
+ActiveRecord::Schema.define(version: 2023_01_17_163549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,7 +145,6 @@ ActiveRecord::Schema.define(version: 2023_01_03_072531) do
     t.string "summary"
     t.bigint "post_count_this_week", default: 0
     t.string "category"
-    t.integer "owner_id"
     t.string "slug"
     t.index ["account_id"], name: "index_communities_on_account_id"
     t.index ["slug"], name: "index_communities_on_slug", unique: true


### PR DESCRIPTION
In Community model,  owner_id field is removed because both account_id and owner_id field denotes the same. Used account_id in all occurances.